### PR TITLE
chore: wrap auth logs in dev check

### DIFF
--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -9,11 +9,19 @@ export const useAuthStore = defineStore('auth', () => {
   const loading = ref(true);
 
   // --- ✅ ЛОГИРОВАНИЕ ВНУТРИ ХРАНИЛИЩА ---
-  console.log('[AUTH STORE] Initializing...');
+  if (import.meta.env.DEV) {
+    console.log('[AUTH STORE] Initializing...');
+  }
 
   const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
     // Этот лог покажет нам КАЖДЫЙ раз, когда Firebase меняет статус
-    console.log(`%c[FIREBASE AUTH STATE CHANGED] User status updated.`, 'color: #881391; font-weight: bold;', firebaseUser ? `Logged in as ${firebaseUser.email}` : 'Logged out.');
+    if (import.meta.env.DEV) {
+      console.log(
+        `%c[FIREBASE AUTH STATE CHANGED] User status updated.`,
+        'color: #881391; font-weight: bold;',
+        firebaseUser ? `Logged in as ${firebaseUser.email}` : 'Logged out.'
+      );
+    }
     user.value = firebaseUser;
     loading.value = false;
   });


### PR DESCRIPTION
## Summary
- log auth initialization and state changes only in dev

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b60293f1e4832b922b1068d796c1ba