### PR TITLE
feat: enable novena notifications via PWA

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -244,6 +244,7 @@ import { usePageMode } from '@/composables/usePageMode'; // ✅ Импорт
 import { useAuthStore } from '@/stores/auth';
 import { notifier } from '@/composables/useNotifier';
 import { useNovenaSuggestions } from '@/composables/useNovenaSuggestions';
+import { useNovenaNotifications } from '@/composables/useNovenaNotifications';
 import FilterSheet from '@/components/FilterSheet.vue';
 import NotificationSnackbar from '@/components/NotificationSnackbar.vue';
 import TextSettingsSheet from '@/components/TextSettingsSheet.vue'; // ✅ ИМПОРТ
@@ -261,6 +262,7 @@ const { items, isLoading } = useItems();
 const { isDrawerOpen, isSearchActive, isFilterSheetOpen, isTextSettingsSheetOpen  } = useAppBar();
 const { selectedTags, search } = useFilters();
 const { suggestion, checkSuggestions, viewSuggestedNovena, dismissSuggestion } = useNovenaSuggestions();
+const { scheduleTodayNotifications } = useNovenaNotifications();
 const { isEditing, toggleEditing } = usePageMode(); // ✅ Получаем состояние
 
 const snackbar = ref(null);
@@ -315,8 +317,18 @@ function openTextSettings() {
 watch(isLoading, (newIsLoading) => {
   if (!newIsLoading && settings.novenaNotificationsEnabled) {
     checkSuggestions();
+    scheduleTodayNotifications();
   }
 });
+
+watch(
+  () => settings.novenaNotificationsEnabled,
+  (enabled) => {
+    if (enabled && !isLoading.value) {
+      scheduleTodayNotifications();
+    }
+  }
+);
 
 watch(() => route.name, (newName) => {
   console.group(`[App.vue WATCHER] Имя маршрута изменилось!`);

--- a/src/composables/useNovenaNotifications.js
+++ b/src/composables/useNovenaNotifications.js
@@ -1,0 +1,44 @@
+import { useNovenaStore } from '@/stores/novena';
+import { useItems } from '@/composables/useItems';
+import { getTitleByLang } from '@/utils/i18n';
+import { useSettingsStore } from '@/stores/settings';
+
+export function useNovenaNotifications() {
+  const novenaStore = useNovenaStore();
+  const settings = useSettingsStore();
+  const { items } = useItems();
+
+  async function scheduleTodayNotifications() {
+    if (!settings.novenaNotificationsEnabled) return;
+    if (typeof window === 'undefined') return;
+    if (!('Notification' in window)) return;
+
+    if (Notification.permission !== 'granted') {
+      try {
+        const perm = await Notification.requestPermission();
+        if (perm !== 'granted') return;
+      } catch (err) {
+        return;
+      }
+    }
+
+    const today = novenaStore.getTodayDateString();
+    for (const [noteId, novena] of Object.entries(novenaStore.novenas)) {
+      if (!novena.completedDates.includes(today)) {
+        const item = items.value.find((i) => i.id === noteId);
+        const title = item ? getTitleByLang(item) : 'Novena';
+        const dayNumber = novena.completedDates.length + 1;
+        const body = `День ${dayNumber} новенны`;
+
+        try {
+          const reg = await navigator.serviceWorker.ready;
+          reg.showNotification(title, { body });
+        } catch (err) {
+          new Notification(title, { body });
+        }
+      }
+    }
+  }
+
+  return { scheduleTodayNotifications };
+}

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import i18n from './i18n'
 import './firebase' // Импортируем для инициализации Firebase
 import '@mdi/font/css/materialdesignicons.css'
 import './styles/main.css'
+import { registerSW } from 'virtual:pwa-register'
 
 const app = createApp(App)
 
@@ -16,3 +17,5 @@ app.use(vuetify)
 app.use(i18n)
 
 app.mount('#app')
+
+registerSW({ immediate: true })

--- a/src/stores/settings.js
+++ b/src/stores/settings.js
@@ -45,6 +45,25 @@ const novenaNotificationsEnabled = ref(JSON.parse(localStorage.getItem('prayer-n
   watch(pinnedIds, (v) => localStorage.setItem('pinnedIds', JSON.stringify(v)), { deep: true });
   watch(menuCategories, (v) => localStorage.setItem('menuCategories', JSON.stringify(v)), { deep: true });
   watch(showHiddenItems, (v) => localStorage.setItem('showHiddenItems', v));
+  watch(
+    novenaNotificationsEnabled,
+    async (enabled) => {
+      localStorage.setItem('prayer-novena-notifications', enabled);
+      if (enabled && 'Notification' in window) {
+        if (Notification.permission !== 'granted') {
+          try {
+            const perm = await Notification.requestPermission();
+            if (perm !== 'granted') {
+              novenaNotificationsEnabled.value = false;
+            }
+          } catch (err) {
+            novenaNotificationsEnabled.value = false;
+          }
+        }
+      }
+    },
+    { immediate: true }
+  );
 
   // --- Функции для изменения состояний (Actions) ---
   function toggleTheme() { currentTheme.value = currentTheme.value === 'light' ? 'dark' : 'light'; }

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
       registerType: 'prompt',
       injectRegister: 'auto',
       strategies: 'generateSW',
+      devOptions: { enabled: true },
       workbox: {
         cleanupOutdatedCaches: true,
         globPatterns: ['**/*.{js,css,html,ico,png,svg,json,vue,txt,woff2,webmanifest}'],


### PR DESCRIPTION
## Summary
- register service worker and enable PWA dev mode
- schedule daily notifications for active novenas
- persist notification preference with permission checks

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b603d0ad10832bade3ed0d67fe3c59